### PR TITLE
Фоновый цвет для картинок

### DIFF
--- a/scss/Habrahabr Darkness/components/page.scss
+++ b/scss/Habrahabr Darkness/components/page.scss
@@ -17,6 +17,9 @@
 .tm-comment__body-content_v2 .mention,
 .tm-comment-navigation__block,
 .tm-layout__container,
+.article-formatted-body img {
+  background-color: $text-color-main;
+}
 .article-formatted-body code,
 .article-formatted-body pre,
 .article-formatted-body_version-2 details,


### PR DESCRIPTION
Если в тексте есть картинка с текстом и прозрачным фоном (например https://habr.com/ru/post/676858/), то текст на этой картинке не читаем. Серый фон добавляет читаемости и не режет глаз слишком большим контрастом