### PR TITLE
Fix article title color

### DIFF
--- a/scss/Habrahabr Darkness/components/page.scss
+++ b/scss/Habrahabr Darkness/components/page.scss
@@ -166,6 +166,16 @@
   color: $link-color-hover;
 }
 
+/* Article header */
+.tm-title {
+  color: $text-color-main!important;
+}
+
+/* Other news */
+.tm-title__link {
+  color: $text-color-main!important;
+}
+
 /* Style fixes */
 .tm-suggest-button:hover {
   background-color: #7aa600 !important;


### PR DESCRIPTION
URL: https://habr.com/ru/news/t/725078/

Artilce header
before: 
![image](https://user-images.githubusercontent.com/1235286/228505727-5102750a-c5a6-4d78-9f24-256351cb6c64.png)
after:
![image](https://user-images.githubusercontent.com/1235286/228505752-87c26b17-9de9-47a0-87d6-b50f4d6783d0.png)

Other news:
before:
![image](https://user-images.githubusercontent.com/1235286/228815570-cb8ac329-35de-4173-9380-777261d18c45.png)
after:
![image](https://user-images.githubusercontent.com/1235286/228815646-5691190b-b348-4a20-90eb-984ca81484b3.png)
(color on the screenshot is white but in this MR is #b3b3b3
